### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -447,7 +447,7 @@ class JsonServiceClient implements IServiceClient {
     }
 
     if (responseAs is String) {
-      var bodyStr = await res.transform(utf8.decoder).join();
+      var bodyStr = await res.cast<List<int>>().transform(utf8.decoder).join();
       return bodyStr as T;
     }
 
@@ -459,7 +459,7 @@ class JsonServiceClient implements IServiceClient {
     var isJson =
         contentType != null && contentType.indexOf("application/json") != -1;
     if (isJson) {
-      var jsonObj = json.decode(await res.transform(utf8.decoder).join());
+      var jsonObj = json.decode(await res.cast<List<int>>().transform(utf8.decoder).join());
       if (responseAs == null) {
         return jsonObj as T;
       }
@@ -510,7 +510,7 @@ class JsonServiceClient implements IServiceClient {
       return null;
     }
 
-    return json.decode(await res.transform(utf8.decoder).join());
+    return json.decode(await res.cast<List<int>>().transform(utf8.decoder).join());
   }
 
   handleError(HttpClientResponse holdRes, Exception e,
@@ -534,7 +534,7 @@ class JsonServiceClient implements IServiceClient {
       ..type = type;
 
     try {
-      String str = await res.transform(utf8.decoder).join();
+      String str = await res.cast<List<int>>().transform(utf8.decoder).join();
       if (!isJsonObject(str)) {
         webEx.responseStatus = createErrorResponse(
                 res.statusCode.toString(), res.reasonPhrase, type)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: servicestack
-version: 1.0.10
+version: 1.0.10+1
 author: ServiceStack, Inc <team@servicestack.net>
 description: ServiceStack's convenience utils for developing Dart VM and flutter apps. Integrates with ServiceStack's Server features including ServiceClient, Error Handling and Validation
 homepage: https://github.com/ServiceStack/servicestack-dart


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900