### PR TITLE
fix content length error

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -391,7 +391,7 @@ class JsonServiceClient implements IServiceClient {
 
     if (bodyStr != null) {
       req.headers.contentType = ContentType.json;
-      req.contentLength = bodyStr.length;
+      req.contentLength = utf8.encode(bodyStr).length;
     }
 
     if (info.requestFilter != null) {


### PR DESCRIPTION
when use chinese or other multibyte charset in the request, the content length must use the utf8 decoded length