### PR TITLE
Use number of bytes as contentLength

### DIFF
--- a/lib/client.dart
+++ b/lib/client.dart
@@ -391,7 +391,7 @@ class JsonServiceClient implements IServiceClient {
 
     if (bodyStr != null) {
       req.headers.contentType = ContentType.json;
-      req.contentLength = bodyStr.length;
+      req.contentLength = utf8.encode(bodyStr).length;
     }
 
     if (info.requestFilter != null) {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -25,6 +25,14 @@ void main() {
     expect(response.result, equals("Hello, World!"));
   });
 
+  test('Can SEND umlauts', () async {
+    var client = createTestClient();
+    var request = new Hello(name: "üöäß");
+    HelloResponse response = await client.post(request);
+
+    expect(response.result, equals("Hello, üöäß!"));
+  });
+
   test('Does fire Request and Response Filters', () async {
     var client = createTestClient();
     var events = new List<String>();


### PR DESCRIPTION
to support e.g. german umlauts and prevent the exception: Content size exceeds specified contentLength. 44 bytes written while expected 40.