### PR TITLE
Use StreamTransformer.bind() rather than Stream.transform()

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To make API calls we need to use the `JsonServiceClient`, installed by adding th
 
 ```yaml
 dependencies:
-  servicestack: ^1.0.10
+  servicestack: ^1.0.11
 ```
 
 Saving `pubspec.yaml` in VS Code with the [Dart Code Extension](https://dartcode.org) automatically calls `pub get` or `flutter packages get` (in Flutter projects) to add any new dependencies to your project.

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -447,7 +447,7 @@ class JsonServiceClient implements IServiceClient {
     }
 
     if (responseAs is String) {
-      var bodyStr = await res.cast<List<int>>().transform(utf8.decoder).join();
+      var bodyStr = await utf8.decoder.bind(res).join();
       return bodyStr as T;
     }
 
@@ -459,7 +459,7 @@ class JsonServiceClient implements IServiceClient {
     var isJson =
         contentType != null && contentType.indexOf("application/json") != -1;
     if (isJson) {
-      var jsonObj = json.decode(await res.cast<List<int>>().transform(utf8.decoder).join());
+      var jsonObj = json.decode(await utf8.decoder.bind(res).join());
       if (responseAs == null) {
         return jsonObj as T;
       }
@@ -510,7 +510,7 @@ class JsonServiceClient implements IServiceClient {
       return null;
     }
 
-    return json.decode(await res.cast<List<int>>().transform(utf8.decoder).join());
+    return json.decode(await utf8.decoder.bind(res).join());
   }
 
   handleError(HttpClientResponse holdRes, Exception e,
@@ -534,7 +534,7 @@ class JsonServiceClient implements IServiceClient {
       ..type = type;
 
     try {
-      String str = await res.cast<List<int>>().transform(utf8.decoder).join();
+      String str = await utf8.decoder.bind(res).join();
       if (!isJsonObject(str)) {
         webEx.responseStatus = createErrorResponse(
                 res.statusCode.toString(), res.reasonPhrase, type)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: servicestack
-version: 1.0.10+1
+version: 1.0.11
 author: ServiceStack, Inc <team@servicestack.net>
 description: ServiceStack's convenience utils for developing Dart VM and flutter apps. Integrates with ServiceStack's Server features including ServiceClient, Error Handling and Validation
 homepage: https://github.com/ServiceStack/servicestack-dart


### PR DESCRIPTION
The fixes in https://github.com/ServiceStack/servicestack-dart/pull/1 work, but they're
more impervious to future API change if we call
`StreamTransformer.bind()` rather than `Stream.transform()`,
as it puts the argument in a covariant position.