### PR TITLE
update http 0.12.x -> 0.13.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,6 @@ homepage: https://github.com/ServiceStack/servicestack-dart
 environment:
   sdk: '>=2.7.0 <3.0.0'
 dependencies:
-  http: ^0.12.2
+  http: ^0.13.3
 dev_dependencies:
   test: ^1.15.7


### PR DESCRIPTION
you already have a PR open for null safety. we currently have problems with other dependencies because servicestack relies on an old http version which blocks us from upgrading the others.

tests did all run properly. maybe this can be released sooner as the null-safety dart client?