### PR TITLE
null safety: toDouble returns double? as null is an expected return value

### DIFF
--- a/lib/json_converters.dart
+++ b/lib/json_converters.dart
@@ -67,7 +67,7 @@ class JsonConverters {
     return converter.toJson(value, newContext);
   }
 
-  static double toDouble(dynamic value) {
+  static double? toDouble(dynamic value) {
     if (value == null || value is double) {
       return value;
     }


### PR DESCRIPTION
null safety: toDouble(dynamic value) returns double? as null is an expected return value

dart mapping code generator needs to be adapted. when mapping to `double` use ! on toDouble(value) call.
eg:
```
doubleField = JsonConverters.toDouble(json['doubleField'])!;

nullableDoubleField = JsonConverters.toDouble(json['nullableDoubleField']);
```
